### PR TITLE
feat(facts): derive Serialize on Facts, Personality, RouteEngine

### DIFF
--- a/rustez/Cargo.toml
+++ b/rustez/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustez"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "A Rust replacement for Juniper PyEZ — async-first Junos automation built on rustnetconf"
@@ -16,6 +16,8 @@ tokio = { version = "1", features = ["full"] }
 quick-xml = "0.37"
 thiserror = "2"
 tracing = "0.1"
+serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
+serde_json = "1"
 serial_test = "3"

--- a/rustez/src/facts/mod.rs
+++ b/rustez/src/facts/mod.rs
@@ -11,13 +11,14 @@ pub mod software;
 use std::time::Duration;
 
 use rustnetconf::Client;
+use serde::Serialize;
 
 use crate::error::RustEzError;
 pub use personality::{detect_personality, Personality};
 pub use routing_engine::RouteEngine;
 
 /// Collected facts about a Junos device.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct Facts {
     /// Device hostname.
     pub hostname: String,
@@ -326,5 +327,55 @@ mod tests {
         let items = unwrap_multi_re(xml);
         let is_cluster = items.len() > 1;
         assert!(!is_cluster);
+    }
+
+    #[test]
+    fn facts_serializes_to_json_with_snake_case_fields() {
+        let facts = Facts {
+            hostname: "lab-r1.example.net".to_string(),
+            model: "vSRX".to_string(),
+            version: "23.4R1.10".to_string(),
+            serial_number: "VM5A1234".to_string(),
+            personality: Personality::Vsrx,
+            route_engines: vec![RouteEngine {
+                slot: Some(0),
+                status: "OK".to_string(),
+                model: Some("RE-VSRX".to_string()),
+                mastership_state: Some("master".to_string()),
+                uptime: Some("3 days".to_string()),
+                memory_total: Some("4096 MB".to_string()),
+            }],
+            master_re: Some(0),
+            domain: Some("example.net".to_string()),
+            fqdn: Some("lab-r1.example.net".to_string()),
+            is_cluster: false,
+        };
+
+        let value = serde_json::to_value(&facts).unwrap();
+
+        // Top-level snake_case fields are preserved (no rename_all on Facts).
+        assert_eq!(value["hostname"], "lab-r1.example.net");
+        assert_eq!(value["serial_number"], "VM5A1234");
+        assert_eq!(value["is_cluster"], false);
+        assert_eq!(value["master_re"], 0);
+
+        // Personality serializes as a lowercase string for known variants.
+        assert_eq!(value["personality"], "vsrx");
+
+        // Nested RouteEngine serializes with snake_case fields.
+        let re = &value["route_engines"][0];
+        assert_eq!(re["slot"], 0);
+        assert_eq!(re["status"], "OK");
+        assert_eq!(re["mastership_state"], "master");
+        assert_eq!(re["memory_total"], "4096 MB");
+    }
+
+    #[test]
+    fn personality_unknown_serializes_with_model_payload() {
+        let p = Personality::Unknown("FutureRouter9000".to_string());
+        let value = serde_json::to_value(&p).unwrap();
+        // Unknown is the only variant carrying data — serializes as a tagged
+        // object: {"unknown": "FutureRouter9000"}.
+        assert_eq!(value["unknown"], "FutureRouter9000");
     }
 }

--- a/rustez/src/facts/personality.rs
+++ b/rustez/src/facts/personality.rs
@@ -2,8 +2,14 @@
 
 use std::fmt;
 
+use serde::Serialize;
+
 /// The personality (platform family) of a Junos device.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// Serializes as a lowercase string for known variants (e.g., `"vsrx"`,
+/// `"mx"`) or `{"unknown": "<model>"}` for unrecognized models.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
 pub enum Personality {
     Mx,
     Vmx,

--- a/rustez/src/facts/routing_engine.rs
+++ b/rustez/src/facts/routing_engine.rs
@@ -2,9 +2,10 @@
 
 use quick_xml::events::Event;
 use quick_xml::Reader;
+use serde::Serialize;
 
 /// Information about a single routing engine.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize)]
 pub struct RouteEngine {
     /// RE slot number (e.g., 0, 1).
     pub slot: Option<u32>,


### PR DESCRIPTION
## Summary
- Add `serde::Serialize` derive on `Facts`, `Personality`, `RouteEngine` so consumers can `serde_json::to_value(&facts)` instead of hand-rolling each field.
- Add `serde` (with `derive`) as a non-optional dependency.
- Personality serializes as a lowercase string for known variants (`"vsrx"`, `"mx"`, ...) and as `{"unknown": "<model>"}` for the data-carrying `Unknown` variant.
- Bump `rustez` to `0.8.4`.

Motivated by RustJunosMCP, which currently hand-builds JSON in `helpers::facts_to_json` and is awaiting this change to drop that hack.

## Test Plan
- [x] `cargo build -p rustez`
- [x] `cargo test -p rustez` (17 facts tests pass, including 2 new serialization round-trip tests)
- [x] `cargo clippy -p rustez --all-targets -- -D warnings`