### PR TITLE
feat(config): ConfigManager::commit_with_comment

### DIFF
--- a/rustez/src/config.rs
+++ b/rustez/src/config.rs
@@ -147,6 +147,17 @@ impl<'a> ConfigManager<'a> {
         timed(timeout, self.client.commit_configuration()).await
     }
 
+    /// Commit the candidate configuration with a log comment.
+    ///
+    /// Sends the Junos-native `<commit-configuration><log>…</log></commit-configuration>`
+    /// RPC. The comment is XML-escaped before being embedded, so any string
+    /// (including untrusted input) is safe to pass.
+    pub async fn commit_with_comment(&mut self, comment: &str) -> Result<(), RustEzError> {
+        let timeout = self.timeout;
+        let xml = build_commit_with_comment_xml(comment);
+        timed(timeout, self.client.rpc(&xml)).await.map(|_| ())
+    }
+
     /// Validate the candidate configuration without committing.
     pub async fn commit_check(&mut self) -> Result<(), RustEzError> {
         let timeout = self.timeout;
@@ -256,6 +267,18 @@ fn build_load_xml(payload: &ConfigPayload) -> String {
     }
 }
 
+/// Build the `<commit-configuration><log>…</log></commit-configuration>` XML
+/// for a Junos commit with a log comment.
+///
+/// Uses the `nc:` namespace prefix to match rustnetconf's RPC envelope.
+/// The comment is XML-escaped to prevent injection — any string is safe.
+fn build_commit_with_comment_xml(comment: &str) -> String {
+    let escaped = escape(comment);
+    format!(
+        "<{NC}commit-configuration><{NC}log>{escaped}</{NC}log></{NC}commit-configuration>"
+    )
+}
+
 /// Extract text from `<configuration-output>` tags, or return trimmed response.
 fn parse_configuration_output(xml: &str) -> String {
     if let Some(start) = xml.find("<configuration-output>") {
@@ -312,6 +335,38 @@ mod tests {
         let xml = build_load_xml(&payload);
         assert!(!xml.contains("<evil/>"));
         assert!(xml.contains("&lt;evil/&gt;"));
+    }
+
+    #[test]
+    fn test_build_commit_with_comment_xml_simple() {
+        let xml = build_commit_with_comment_xml("automated change");
+        assert_eq!(
+            xml,
+            "<nc:commit-configuration><nc:log>automated change</nc:log></nc:commit-configuration>"
+        );
+    }
+
+    #[test]
+    fn test_build_commit_with_comment_xml_escapes_specials() {
+        let xml = build_commit_with_comment_xml("rev </nc:log><rollback/> & more");
+        // Closing tags and ampersands inside the comment must be escaped so
+        // the resulting RPC body has exactly one balanced <nc:log>…</nc:log>.
+        assert!(!xml.contains("<rollback/>"));
+        assert!(xml.contains("&lt;/nc:log&gt;"));
+        assert!(xml.contains("&lt;rollback/&gt;"));
+        assert!(xml.contains("&amp; more"));
+        // Exactly one open and one close tag.
+        assert_eq!(xml.matches("<nc:log>").count(), 1);
+        assert_eq!(xml.matches("</nc:log>").count(), 1);
+    }
+
+    #[test]
+    fn test_build_commit_with_comment_xml_empty_comment() {
+        let xml = build_commit_with_comment_xml("");
+        assert_eq!(
+            xml,
+            "<nc:commit-configuration><nc:log></nc:log></nc:commit-configuration>"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `ConfigManager::commit_with_comment(&self, comment: &str)` that sends the Junos-native `<commit-configuration><log>…</log></commit-configuration>` RPC.
- Comment is XML-escaped via `quick_xml::escape::escape`, so any string (including untrusted input, closing tags, ampersands) is safe to pass.
- Implementation uses the existing `rustnetconf::Client::rpc` raw path, so **no rustnetconf release is required**. A typed counterpart can be added in rustnetconf later and swapped in without breaking this API.
- 3 new unit tests covering the simple case, XML-escaping of specials, and the empty-comment edge case.

Motivated by RustJunosMCP, which currently hand-rolls this RPC + escaping in `tools::load_commit::handle` via raw `dev.rpc()?.call_xml(...)`. After this lands, that hack drops to a one-liner.

This PR does **not** bump the version. It's intended to land together with #15 in `0.8.4`.

## Test Plan
- [x] `cargo test -p rustez` (43 tests pass, 3 new in `config::tests`)
- [x] `cargo clippy -p rustez --all-targets -- -D warnings`