### PR TITLE
docs(security): triage RUSTSEC-2026-0190 (anyhow < 1.0.103 downcast_mut unsoundness)

### DIFF
--- a/docs/superpowers/research/2026-07-02-rustsec-2026-0190-anyhow.md
+++ b/docs/superpowers/research/2026-07-02-rustsec-2026-0190-anyhow.md
@@ -1,0 +1,87 @@
+# RUSTSEC-2026-0190 (`anyhow` `Error::downcast_mut` unsoundness) — analysis & fix
+
+**Date:** 2026-07-02
+**Issue:** fastrevmd-lab/rustEZ#26
+**Advisory:** https://rustsec.org/advisories/RUSTSEC-2026-0190
+**Outcome:** local resolve refreshed `anyhow 1.0.102 → 1.0.103`. `Cargo.lock` is **gitignored**
+in this repo, so nothing is committed for the fix and no crate version bump / republish is needed —
+CI regenerates the lock and now auto-resolves the patched `1.0.103`. This doc is the tracked record.
+
+## TL;DR
+
+`cargo audit` flagged **RUSTSEC-2026-0190** against `anyhow 1.0.102` in `Cargo.lock`. The
+advisory is a real (safe-code-triggerable) unsoundness, but in rustEZ `anyhow` is a **phantom
+transitive dependency reachable only on a wasm target we never build**, so the flaw is
+unreachable in any real rustEZ / rustez-cli build. Fixed by bumping the lock entry to the
+patched `1.0.103` — the same bump `rustnetconf` already took.
+
+## The advisory
+
+- **Title:** Unsoundness in `Error::downcast_mut()`.
+- **Category:** INFO — Unsound / memory-corruption (no CVSS assigned).
+- **Affected:** `anyhow < 1.0.103`. **Patched:** `>= 1.0.103` (upstream commit `6e8c000`).
+- **Nature:** Adding context via `Error::context` and then calling `Error::downcast_mut` on the
+  returned `Error` constructs the mutable reference from a borrow chain that still contains a
+  shared reference — a Stacked-Borrows violation. Miri:
+  *"trying to retag from &lt;1538&gt; for Unique permission … but that tag only grants
+  SharedReadOnly permission for this location."*
+- **Trigger:** **safe code** — no `unsafe` needed in the caller.
+
+## Reachability in rustEZ — effectively nil
+
+`anyhow` is **not** a direct dependency of `rustez`, `rustez-py`, or `rustez-cli`. It enters the
+lockfile only via a deep, target-gated chain (from the `cargo audit` dependency tree):
+
+```
+anyhow 1.0.102
+└── wit-parser → wit-component → wit-bindgen-rust(-macro) → wit-bindgen
+    └── wasip3 0.4.0
+        └── getrandom 0.4.2
+            ├── tempfile 3.27.0   (rustez dev-dependency)
+            ├── russh 0.61.2      (via rustnetconf)
+            └── rand 0.10.1       (via russh)
+```
+
+The `getrandom 0.4.2 → wasip3 → … → anyhow` edge is gated on the `wasm32-wasip3` target. On a
+normal host:
+
+```
+$ cargo tree -i anyhow                 # warning: nothing to print.
+$ cargo tree --target all -i anyhow    # warning: nothing to print.
+```
+
+`anyhow` is absent from every real build graph. rustEZ is a tokio-based Junos NETCONF automation
+library; it is never compiled to wasm. The unsound `downcast_mut` path is therefore unreachable
+in practice — the audit hit is lockfile hygiene, not an exploitable condition.
+
+## Why nothing is committed for the fix
+
+- `Cargo.lock` is **gitignored** in this repo (`/.gitignore` lists `Cargo.lock`), so there is no
+  tracked lockfile to change. CI regenerates the lock from `Cargo.toml` on each run.
+- Nothing in the workspace **pins** `anyhow` (it is a phantom transitive dep), so a fresh resolve
+  simply picks the newest compatible release — now `1.0.103`, the patched version. The advisory
+  clears automatically; the 1.0.102 hit was a stale local lock.
+- `rustez` is a **library** (crates.io ignores a library's lock; consumers resolve `anyhow`
+  themselves) and `rustez-cli` is **not published**, so there is no `X.Y.Z` bump, `cargo publish`,
+  or tag involved.
+
+## Fix applied
+
+Refresh the local lock so dev/audit runs match CI's fresh-resolve behavior:
+
+```sh
+cargo update -p anyhow --precise 1.0.103
+```
+
+### Verification
+
+- `cargo audit` — RUSTSEC-2026-0190 occurrences: **0** (no vulnerabilities remaining; the only
+  residual is the pre-existing *allowed* yanked-`aes 0.9.0` warning).
+- `cargo check --workspace` — clean.
+- `cargo test -p rustez` — 52 passed.
+
+## Notes
+
+- Mirrors `rustnetconf`'s `chore(deps): update anyhow 1.0.103`.
+- If the phantom `wasip3`/`getrandom 0.4.2` chain keeps surfacing wasm-only advisories, consider
+  a documented `[advisories] ignore` in `audit.toml` — not warranted for a single one-line bump.


### PR DESCRIPTION
Closes #26.

## Summary

`cargo audit` flagged **RUSTSEC-2026-0190** — unsoundness in `anyhow::Error::downcast_mut()` (safe-code-triggerable Stacked-Borrows violation; affected `< 1.0.103`, patched `1.0.103`). Our local lock had `anyhow 1.0.102`.

## Triage

`anyhow` is **not** a direct dep of any workspace crate. It enters only via a target-gated wasm chain — `getrandom 0.4.2 → wasip3 → wit-bindgen → … → anyhow` — that resolves solely for `wasm32-wasip3`. `cargo tree -i anyhow` (even `--target all`) reports *"nothing to print"* on real hosts. rustEZ is a tokio Junos automation library, never built for wasm, so the unsound path is **unreachable** in practice.

## Fix

`Cargo.lock` is **gitignored** in this repo, so nothing is pinned and there's no tracked lockfile to change. CI regenerates the lock on each run and now auto-resolves the patched `anyhow 1.0.103`. Local `cargo update -p anyhow --precise 1.0.103` refreshes dev/audit runs to match. No crate version bump, no republish (library ignores lock downstream; rustez-cli unpublished).

This PR commits the triage/analysis dump only.

## Verification

- `cargo audit` → RUSTSEC-2026-0190 occurrences: **0** (only residual is the pre-existing allowed yanked-`aes 0.9.0` warning)
- `cargo check --workspace` clean · `cargo test -p rustez` → 52 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CALA6Gum4MdPTeEPf6vant