### PR TITLE
Bump rustnetconf to 0.13 and fix vSRX route-engine facts (#30)

### DIFF
--- a/rustez-cli/Cargo.toml
+++ b/rustez-cli/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/fastrevmd-lab/rustez"
 
 [dependencies]
 rustez = { path = "../rustez" }
-rustnetconf = "0.12"
+rustnetconf = "0.13"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }

--- a/rustez-py/Cargo.toml
+++ b/rustez-py/Cargo.toml
@@ -13,6 +13,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustez = { path = "../rustez" }
-rustnetconf = "0.12"
+rustnetconf = "0.13"
 pyo3 = { version = "0.29", features = ["extension-module"] }
 tokio = { version = "1", features = ["full"] }

--- a/rustez/Cargo.toml
+++ b/rustez/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming"]
 rust-version = "1.79"
 
 [dependencies]
-rustnetconf = "0.12.3"
+rustnetconf = "0.13"
 tokio = { version = "1", features = ["full"] }
 quick-xml = "0.41"
 thiserror = "2"

--- a/rustez/src/facts/routing_engine.rs
+++ b/rustez/src/facts/routing_engine.rs
@@ -94,6 +94,16 @@ pub(crate) fn parse_route_engines(xml: &str) -> Vec<RouteEngine> {
                             "memory-dram-size" | "memory-installed-size" => {
                                 engine.memory_total = Some(value);
                             }
+                            "memory-system-total" => {
+                                // vSRX emits bare numbers; normalize to "N MB" for consistency
+                                // with MX/RE-VMX format. Only append if no unit is already present.
+                                let normalized = if value.chars().all(|c| c.is_ascii_digit()) {
+                                    format!("{} MB", value)
+                                } else {
+                                    value
+                                };
+                                engine.memory_total = Some(normalized);
+                            }
                             _ => {}
                         }
                     }
@@ -114,13 +124,33 @@ pub(crate) fn parse_route_engines(xml: &str) -> Vec<RouteEngine> {
 }
 
 /// Determine the master RE index from a list of route engines.
+///
+/// Returns the index of the RE whose mastership-state contains "master".
+///
+/// Standalone platforms (e.g. vSRX) omit `<mastership-state>` entirely. When no
+/// RE reports any mastership state and there is exactly one RE, it is treated as
+/// the master. A lone RE that explicitly reports a non-master state is left
+/// alone — the device's own answer wins over the standalone inference.
 pub(crate) fn find_master_re(engines: &[RouteEngine]) -> Option<usize> {
-    engines.iter().position(|re| {
+    let master_idx = engines.iter().position(|re| {
         re.mastership_state
             .as_deref()
-            .map(|s| s.to_lowercase().contains("master"))
+            .map(|state| state.to_lowercase().contains("master"))
             .unwrap_or(false)
-    })
+    });
+
+    if master_idx.is_some() {
+        return master_idx;
+    }
+
+    // Only infer mastership when the device reported none at all; a single RE
+    // that explicitly said "backup" must not be reported as master.
+    let any_state_reported = engines.iter().any(|re| re.mastership_state.is_some());
+    if engines.len() == 1 && !any_state_reported {
+        return Some(0);
+    }
+
+    None
 }
 
 #[cfg(test)]
@@ -192,5 +222,126 @@ mod tests {
         let engines = parse_route_engines(xml);
         assert_eq!(engines.len(), 1);
         assert_eq!(engines[0].model.as_deref(), Some("RE&A<B"));
+    }
+
+    #[test]
+    fn test_vsrx_standalone() {
+        // Real vSRX 24.4R1.9 output — bareword memory-system-total, no mastership-state, no slot element
+        let xml = r#"<rpc-reply xmlns:junos="http://xml.juniper.net/junos/24.4R1.9/junos">
+    <route-engine-information xmlns="http://xml.juniper.net/junos/24.4R0/junos-chassis">
+        <route-engine>
+            <status>Testing</status>
+            <memory-system-total>16323</memory-system-total>
+            <memory-system-total-used>10610</memory-system-total-used>
+            <memory-system-total-util>65</memory-system-total-util>
+            <memory-control-plane>4035</memory-control-plane>
+            <memory-control-plane-used>1735</memory-control-plane-used>
+            <memory-control-plane-util>43</memory-control-plane-util>
+            <memory-data-plane>12288</memory-data-plane>
+            <memory-data-plane-used>8847</memory-data-plane-used>
+            <memory-data-plane-util>72</memory-data-plane-util>
+            <cpu-user>2</cpu-user>
+            <cpu-background>0</cpu-background>
+            <cpu-system>8</cpu-system>
+            <cpu-interrupt>0</cpu-interrupt>
+            <cpu-idle>90</cpu-idle>
+            <model>VSRX RE</model>
+            <start-time junos:seconds="1784429468">2026-07-19 02:51:08 UTC</start-time>
+            <up-time junos:seconds="45069">12 hours, 31 minutes, 9 seconds</up-time>
+            <last-reboot-reason>Router rebooted after a normal shutdown.</last-reboot-reason>
+            <load-average-one>9.62</load-average-one>
+            <load-average-five>9.67</load-average-five>
+            <load-average-fifteen>9.63</load-average-fifteen>
+        </route-engine>
+    </route-engine-information>
+</rpc-reply>"#;
+
+        let engines = parse_route_engines(xml);
+        assert_eq!(engines.len(), 1);
+        assert_eq!(engines[0].memory_total.as_deref(), Some("16323 MB"));
+        assert_eq!(engines[0].mastership_state, None);
+        assert_eq!(engines[0].slot, None);
+        assert_eq!(engines[0].status, "Testing");
+        assert_eq!(engines[0].model.as_deref(), Some("VSRX RE"));
+        assert_eq!(engines[0].uptime.as_deref(), Some("12 hours, 31 minutes, 9 seconds"));
+
+        // Single RE with no mastership state should be master
+        assert_eq!(find_master_re(&engines), Some(0));
+    }
+
+    #[test]
+    fn test_two_res_no_mastership() {
+        // Two REs with no mastership-state should yield None
+        let xml = r#"<route-engine-information>
+  <route-engine>
+    <slot>0</slot>
+    <status>OK</status>
+    <model>RE-VMX</model>
+  </route-engine>
+  <route-engine>
+    <slot>1</slot>
+    <status>OK</status>
+    <model>RE-VMX</model>
+  </route-engine>
+</route-engine-information>"#;
+
+        let engines = parse_route_engines(xml);
+        assert_eq!(engines.len(), 2);
+        assert_eq!(engines[0].mastership_state, None);
+        assert_eq!(engines[1].mastership_state, None);
+
+        // Two REs with no mastership state should yield None (don't guess)
+        assert_eq!(find_master_re(&engines), None);
+    }
+
+    #[test]
+    fn test_memory_with_existing_unit() {
+        // Value already carrying a unit must not be double-suffixed
+        let xml = r#"<route-engine-information>
+  <route-engine>
+    <slot>0</slot>
+    <status>OK</status>
+    <memory-dram-size>4096 MB</memory-dram-size>
+  </route-engine>
+</route-engine-information>"#;
+
+        let engines = parse_route_engines(xml);
+        assert_eq!(engines.len(), 1);
+        assert_eq!(engines[0].memory_total.as_deref(), Some("4096 MB"));
+    }
+
+    #[test]
+    fn test_memory_system_total_with_existing_unit() {
+        // Exercises the normalization branch itself: if a platform ever emits
+        // memory-system-total already carrying a unit, it must pass through
+        // untouched rather than becoming "16323 MB MB".
+        let xml = r#"<route-engine-information>
+  <route-engine>
+    <status>Testing</status>
+    <memory-system-total>16323 MB</memory-system-total>
+  </route-engine>
+</route-engine-information>"#;
+
+        let engines = parse_route_engines(xml);
+        assert_eq!(engines.len(), 1);
+        assert_eq!(engines[0].memory_total.as_deref(), Some("16323 MB"));
+    }
+
+    #[test]
+    fn test_single_re_explicit_backup_is_not_master() {
+        // A lone RE that explicitly reports a non-master state must not be
+        // promoted by the standalone inference — the device's answer wins.
+        let xml = r#"<route-engine-information>
+  <route-engine>
+    <slot>1</slot>
+    <status>OK</status>
+    <mastership-state>backup</mastership-state>
+  </route-engine>
+</route-engine-information>"#;
+
+        let engines = parse_route_engines(xml);
+        assert_eq!(engines.len(), 1);
+        assert_eq!(engines[0].mastership_state.as_deref(), Some("backup"));
+        assert_eq!(find_master_re(&engines), None);
     }
 }


### PR DESCRIPTION
Two independent changes, one commit each.

## `chore(deps)`: rustnetconf 0.12.3 → 0.13.0

No source changes required. The release's one source-breaking change — `DeviceConfig.vendor` moving from `Box<dyn VendorProfile>` to `Option<Arc<dyn VendorProfile>>` — doesn't touch anything rustEZ uses; the workspace references neither `DeviceConfig`, `DevicePool`, `VendorProfile`, nor `vendor_profile()`. The rest of 0.13.0 is additive (`Client::unwrap_config()`) or CLI-only.

Also aligns the version spec to `"0.13"` across all three manifests — `rustez` previously pinned `0.12.3` exactly while `rustez-cli`/`rustez-py` used `"0.12"`.

Note `Cargo.lock` is gitignored, so CI resolves this fresh.

## `fix(facts)`: vSRX route-engine memory and mastership — closes #30

Fixed against a **verbatim capture** from vSRX 24.4R1.9, not inference — #30 explicitly asked that the element name not be guessed, and the reporter was blocked capturing it.

The capture turned up a wrinkle the issue didn't anticipate. vSRX emits:

```xml
<memory-system-total>16323</memory-system-total>
```

— a **bare number with no unit**, where MX emits `<memory-dram-size>4096 MB</memory-dram-size>` *with* one. So it wasn't only a missing match arm; there's a format mismatch. The new arm normalizes to `"16323 MB"` so consumers get one shape across platforms, guarded so a value already carrying a unit is never double-suffixed. Units confirmed MB by cross-checking the CLI text renderer against the same elements on a second device.

The capture also confirmed:
- `<mastership-state>` and `<slot>` are **genuinely absent** on standalone vSRX — real device behavior, not parse misses.
- `status: "Testing"` is **genuine vSRX output**, so it's left alone rather than "corrected".

`find_master_re` now treats a lone RE reporting no mastership state as master, fixing the null `master_re`. It deliberately does **not** fabricate the `mastership_state` field — that stays `None`, reflecting what the device actually said. A lone RE that *explicitly* reports a non-master state is left alone; the device's own answer wins over the standalone inference.

## Verification

- `cargo test -p rustez` — 57 unit + 4 doc tests pass (was 52 + 4); 7 integration tests ignored, they need a live vSRX
- `cargo clippy --workspace --all-targets` — no warnings
- `cargo check --workspace --all-targets` — clean
- `cargo audit` — 234 deps, 0 advisories

New tests: the real vSRX fixture, two-REs-without-mastership → `None`, both double-suffix guards, and a lone-explicit-`backup` regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)