### PR TITLE
docs: fix CHANGELOG links after repo rename

### DIFF
--- a/rustez/CHANGELOG.md
+++ b/rustez/CHANGELOG.md
@@ -100,9 +100,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was `AcceptAll`. Since `rustnetconf 0.11` the default has been `RejectAll`
   (fail-closed); the docs now reflect this.
 
-[0.13.0]: https://github.com/fastrevmd-lab/rustEZ/compare/v0.12.1...v0.13.0
-[0.12.1]: https://github.com/fastrevmd-lab/rustEZ/compare/v0.12.0...v0.12.1
-[0.12.0]: https://github.com/fastrevmd-lab/rustEZ/compare/v0.11.0...v0.12.0
+[0.13.0]: https://github.com/fastrevmd-lab/rustez/compare/v0.12.1...v0.13.0
+[0.12.1]: https://github.com/fastrevmd-lab/rustez/compare/v0.12.0...v0.12.1
+[0.12.0]: https://github.com/fastrevmd-lab/rustez/compare/v0.11.0...v0.12.0
 
 ## [0.11.0] — 2026-05-18
 
@@ -113,7 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Python:** Pass `host_key_fingerprint="..."` to `Device(...)` to pin, or use `HostKeyVerification` directly via the native bindings.
 - Integration test harness (`vsrx_builder` in `tests/integration_vsrx.rs`) updated to explicitly request `HostKeyVerification::AcceptAll` since the lab vSRX devices are known-good.
 
-[0.11.0]: https://github.com/fastrevmd-lab/rustEZ/compare/v0.10.1...v0.11.0
+[0.11.0]: https://github.com/fastrevmd-lab/rustez/compare/v0.10.1...v0.11.0
 
 ## [0.10.0] — 2026-05-06
 
@@ -140,7 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synced `rustez-py` version to match core crate.
 - Removed unused `to_netconf_err` function from Python bindings.
 
-[0.10.0]: https://github.com/fastrevmd-lab/rustEZ/compare/v0.9.0...v0.10.0
+[0.10.0]: https://github.com/fastrevmd-lab/rustez/compare/v0.9.0...v0.10.0
 
 ## [0.9.0] — 2026-05-04
 
@@ -159,4 +159,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped `rustnetconf` dependency to `0.9`.
 
-[0.9.0]: https://github.com/fastrevmd-lab/rustEZ/releases/tag/v0.9.0
+[0.9.0]: https://github.com/fastrevmd-lab/rustez/releases/tag/v0.9.0

--- a/rustez/CHANGELOG.md
+++ b/rustez/CHANGELOG.md
@@ -113,7 +113,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Python:** Pass `host_key_fingerprint="..."` to `Device(...)` to pin, or use `HostKeyVerification` directly via the native bindings.
 - Integration test harness (`vsrx_builder` in `tests/integration_vsrx.rs`) updated to explicitly request `HostKeyVerification::AcceptAll` since the lab vSRX devices are known-good.
 
-[0.11.0]: https://github.com/fastrevmd-lab/rustez/compare/v0.10.1...v0.11.0
+[0.11.0]: https://github.com/fastrevmd-lab/rustez/compare/v0.10.0...v0.11.0
 
 ## [0.10.0] — 2026-05-06
 
@@ -140,9 +140,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Synced `rustez-py` version to match core crate.
 - Removed unused `to_netconf_err` function from Python bindings.
 
-[0.10.0]: https://github.com/fastrevmd-lab/rustez/compare/v0.9.0...v0.10.0
+[0.10.0]: https://github.com/fastrevmd-lab/rustez/compare/v0.8.4...v0.10.0
 
-## [0.9.0] — 2026-05-04
+## 0.9.0 — 2026-05-04
+
+<!-- Unlinked: v0.9.0 was never tagged in this repository. The 0.9.0 changes
+     are contained in the v0.8.4...v0.10.0 range linked from 0.10.0 above. -->
 
 ### Added
 
@@ -159,4 +162,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped `rustnetconf` dependency to `0.9`.
 
-[0.9.0]: https://github.com/fastrevmd-lab/rustez/releases/tag/v0.9.0


### PR DESCRIPTION
Documentation only — no code, no version change.

## Two commits

**1. Rename fallout.** The repo was renamed `rustEZ` → `rustez`. The changelog's six compare/release URLs still pointed at the old path, working only via GitHub's redirect — which would break if the old name were ever reclaimed by another repo. Prose references to "rustEZ" as the *project* name are intentional and left alone.

**2. Pre-existing 404s, surfaced by verifying the above.** Three links 404'd even after the path fix, for reasons unrelated to the rename: the changelog referenced **`v0.9.0` and `v0.10.1`, neither of which was ever tagged**. Actual tags run `v0.8.4` → `v0.10.0`, with no `0.10.1` section in the file either, so that reference was always spurious.

| Link | Before | After |
|---|---|---|
| `[0.11.0]` | `compare/v0.10.1...v0.11.0` | `compare/v0.10.0...v0.11.0` |
| `[0.10.0]` | `compare/v0.9.0...v0.10.0` | `compare/v0.8.4...v0.10.0` |
| `[0.9.0]` | `releases/tag/v0.9.0` | heading unlinked, definition dropped |

`0.9.0` has no tag to point at, so rather than fabricate a target the heading is unlinked and a comment records why and where those changes live (inside the `v0.8.4...v0.10.0` range).

## Verification

All five remaining links checked with `curl -L -o /dev/null -w '%{http_code}'` — **every one returns 200**. A reference-integrity check confirms no heading links to an undefined reference and no definition is orphaned.

Not addressed here: whether `v0.9.0` and `v0.10.1` *should* exist as tags. If those releases were really cut and the tags were lost, the better fix is restoring the tags and reverting commit 2 — worth a look, but it's a separate question from making the file's links correct today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)