### PR TITLE
release: rustez 0.13.1 (rustnetconf 0.13.1 / russh 0.62, #34)

### DIFF
--- a/rustez-cli/Cargo.toml
+++ b/rustez-cli/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/fastrevmd-lab/rustez"
 
 [dependencies]
 rustez = { path = "../rustez" }
-rustnetconf = "0.13"
+rustnetconf = "0.13.1"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 serde = { version = "1", features = ["derive"] }

--- a/rustez-py/Cargo.toml
+++ b/rustez-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustez-py"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "Python bindings for rustEZ — pip install rustez"

--- a/rustez-py/Cargo.toml
+++ b/rustez-py/Cargo.toml
@@ -13,6 +13,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 rustez = { path = "../rustez" }
-rustnetconf = "0.13"
+rustnetconf = "0.13.1"
 pyo3 = { version = "0.29", features = ["extension-module"] }
 tokio = { version = "1", features = ["full"] }

--- a/rustez-py/pyproject.toml
+++ b/rustez-py/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "rustez"
-version = "0.13.0"
+version = "0.13.1"
 description = "Python bindings for rustEZ — Junos device automation built on Rust"
 requires-python = ">=3.9"
 license = "MIT"

--- a/rustez/CHANGELOG.md
+++ b/rustez/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the `rustez` crate are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.1] — 2026-07-22
+
+### Changed
+
+- Bumped `rustnetconf` dependency to `0.13.1`, which moves the SSH transport
+  from **russh 0.61 → 0.62** and off the prerelease (`-rc`) RustCrypto stack
+  (#34). No `rustez` source changes were required. The `-rc` crate surface in
+  the lockfile shrinks from ~13 crates to only `ssh-key` and its transitive
+  `argon2` / `blake2` — all gated on RustCrypto + russh upstream, not clearable
+  here.
+
 ## [0.13.0] — 2026-07-19
 
 ### Fixed
@@ -100,6 +111,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   was `AcceptAll`. Since `rustnetconf 0.11` the default has been `RejectAll`
   (fail-closed); the docs now reflect this.
 
+[0.13.1]: https://github.com/fastrevmd-lab/rustez/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/fastrevmd-lab/rustez/compare/v0.12.1...v0.13.0
 [0.12.1]: https://github.com/fastrevmd-lab/rustez/compare/v0.12.0...v0.12.1
 [0.12.0]: https://github.com/fastrevmd-lab/rustez/compare/v0.11.0...v0.12.0

--- a/rustez/Cargo.toml
+++ b/rustez/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustez"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "A Rust replacement for Juniper PyEZ — async-first Junos automation built on rustnetconf"

--- a/rustez/Cargo.toml
+++ b/rustez/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming"]
 rust-version = "1.79"
 
 [dependencies]
-rustnetconf = "0.13"
+rustnetconf = "0.13.1"
 tokio = { version = "1", features = ["full"] }
 quick-xml = "0.41"
 thiserror = "2"


### PR DESCRIPTION
Closes #34. **Full patch release** — supersedes the dep-only scope; unblocks RustJunosMCP bumping its `rustez` pin.

## What
- Pins `rustnetconf = "0.13.1"` across `rustez`, `rustez-py`, `rustez-cli`.
- Bumps package version **0.13.0 → 0.13.1** (`rustez/Cargo.toml`, `rustez-py/Cargo.toml`, `rustez-py/pyproject.toml`) + CHANGELOG entry & compare link.

rustnetconf 0.13.1 moves the SSH transport **russh 0.61.2 → 0.62.4**, off the prerelease RustCrypto stack. No `rustez` source changes.

## `-rc` crypto surface: ~13 → 3
| crate | version | source |
|---|---|---|
| ssh-key | 0.7.0-rc.11 | russh |
| argon2 | 0.6.0-rc.8 | ← ssh-key |
| blake2 | 0.11.0-rc.6 | ← ssh-key |

All chain from `ssh-key → russh` — upstream-gated (matches #34 "Residual"). `pkcs1` cleared. Now stable: curve25519-dalek, ed25519-dalek, ecdsa, elliptic-curve, p256/384/521, ssh-cipher, ssh-encoding, primeorder.

## Verification
- `scripts/check_versions.py` ✓ (all agree on 0.13.1)
- `cargo build --workspace` ✓ · `cargo clippy -p rustez` ✓ (no warnings)
- `cargo test -p rustez` → 57 unit + 4 doctests pass · `cargo audit` → 0 vulns
- `cargo publish -p rustez --dry-run` ✓ (packages clean)

## Post-merge release steps
`git tag -a v0.13.1` (triggers PyPI OIDC publish) → `cargo publish -p rustez` (manual). Live vSRX smoke happens via RustJunosMCP once the crate is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)